### PR TITLE
Criando a rota para trocar um administrador para administrador raiz

### DIFF
--- a/Hotel.Domain/Controllers/AdminContext/AdminController.cs
+++ b/Hotel.Domain/Controllers/AdminContext/AdminController.cs
@@ -54,9 +54,17 @@ public class AdminController : ControllerBase
     [FromRoute] Guid permissionId)
   => Ok(await _handler.HandleAddPermission(adminId, permissionId));
 
+
   [HttpDelete("v1/admins/{adminId:guid}/permissions/{permissionId:guid}")]
   public async Task<IActionResult> RemovePermission(
     [FromRoute] Guid adminId,
     [FromRoute] Guid permissionId)
   => Ok(await _handler.HandleRemovePermission(adminId, permissionId));
+
+
+  [HttpPost("v1/admins/{adminId:guid}/to-root-admin/{toRootAdminId:guid}")]
+  public async Task<IActionResult> ChangeToRootAdmin(
+    [FromRoute] Guid adminId,
+    [FromRoute] Guid toRootAdminId)
+  => Ok(await _handler.HandleChangeToRootAdminAsync(adminId,toRootAdminId));
 }

--- a/Hotel.Domain/DTOs/Response.cs
+++ b/Hotel.Domain/DTOs/Response.cs
@@ -11,16 +11,16 @@ public class Response<T> : IDataTransferObject
     Data = data;
   }
 
+  public Response(int status, string message)
+  {
+    Status = status;
+    Message = message;
+  }
+
   public Response(int status, List<string> errors)
   {
     Status = status;
     Errors = errors;
-  }
-
-  public Response(int status,  string error)
-  {
-    Status = status;
-    Errors.Add(error);
   }
 
   public int Status { get; private set; }

--- a/Hotel.Domain/Entities/AdminContext/AdminEntity/Admin.cs
+++ b/Hotel.Domain/Entities/AdminContext/AdminEntity/Admin.cs
@@ -19,10 +19,12 @@ public partial class Admin : User, IAdmin
 
   public void ChangeToRootAdmin(Admin RootAdmin)
   {
+    if (IsRootAdmin)
+      throw new InvalidOperationException("Esse administrador já é um administrador raiz.");
     if (RootAdmin.IsRootAdmin)
       IsRootAdmin = true;
     else
-      throw new ValidationException("Erro de validação: Não é possível atribuir o status de administrador root a este usuário sem antes possuir um administrador root.");
+      throw new ValidationException("Erro de validação: Esse administrador não é um administrador raiz. Informe um administrador raiz para mudar o status.");
   }
 
 

--- a/Hotel.Domain/Handlers/AdminContext/AdminHandlers/ChangeToRootAdmin.cs
+++ b/Hotel.Domain/Handlers/AdminContext/AdminHandlers/ChangeToRootAdmin.cs
@@ -1,0 +1,23 @@
+﻿using Hotel.Domain.DTOs;
+
+namespace Hotel.Domain.Handlers.AdminContext.AdminHandlers;
+
+public partial class AdminHandler
+{
+  public async Task<Response<object>> HandleChangeToRootAdminAsync(Guid rootAdminId,Guid changeToRootAdminId)
+  {
+    var rootAdmin = await _repository.GetEntityByIdAsync(rootAdminId);
+    if (rootAdmin == null)
+      throw new ArgumentException("Administrador raiz não encontrado.");
+
+    var changeToRootAdmin = await _repository.GetEntityByIdAsync(changeToRootAdminId);
+    if (changeToRootAdmin == null)
+      throw new ArgumentException("Administrador não encontrado.");
+
+    changeToRootAdmin.ChangeToRootAdmin(rootAdmin);
+
+    await _repository.SaveChangesAsync();
+
+    return new Response<object>(200, $"O Administrador {changeToRootAdmin.Name.FirstName} é agora um Administrador raiz.");
+  }
+}

--- a/Hotel.Domain/Handlers/AdminContext/AdminHandlers/Create.cs
+++ b/Hotel.Domain/Handlers/AdminContext/AdminHandlers/Create.cs
@@ -33,6 +33,6 @@ public partial class AdminHandler : IHandler
     await _repository.CreateAsync(admin);
     await _repository.SaveChangesAsync();
 
-    return new Response<object>(200,"Admin criado com sucesso!",new { admin.Id });
+    return new Response<object>(200,"Administrador criado.",new { admin.Id });
   }
 }

--- a/Hotel.Domain/Handlers/AdminContext/AdminHandlers/Delete.cs
+++ b/Hotel.Domain/Handlers/AdminContext/AdminHandlers/Delete.cs
@@ -8,6 +8,6 @@ public partial class AdminHandler
   {
     _repository.Delete(adminId);
     await _repository.SaveChangesAsync();
-    return new Response<object>(200,"Admin deletado com sucesso!", new { adminId });
+    return new Response<object>(200,"Administrador deletado.");
   }
 }

--- a/Hotel.Domain/Handlers/AdminContext/AdminHandlers/GetById.cs
+++ b/Hotel.Domain/Handlers/AdminContext/AdminHandlers/GetById.cs
@@ -9,8 +9,8 @@ public partial class AdminHandler
   {
     var admin = await _repository.GetByIdAsync(adminId);
     if (admin == null)
-      throw new ArgumentException("Admin não encontrado.");
+      throw new ArgumentException("Administrador não encontrado.");
     
-    return new Response<GetUser>(200,"Admin encontrado com sucesso!", admin);
+    return new Response<GetUser>(200,"Administrador encontrado.", admin);
   }
 }

--- a/Hotel.Domain/Handlers/AdminContext/AdminHandlers/Permissions/AddPermission.cs
+++ b/Hotel.Domain/Handlers/AdminContext/AdminHandlers/Permissions/AddPermission.cs
@@ -9,7 +9,7 @@ partial class AdminHandler
     //Buscar admin
     var admin = await _repository.GetAdminIncludePermissions(adminId);
     if (admin == null)
-      throw new ArgumentException("Admin não encontrado.");
+      throw new ArgumentException("Administrador não encontrado.");
 
     //Buscar permissão
     var permission = await _permissionRepository.GetEntityByIdAsync(permissionId);

--- a/Hotel.Domain/Handlers/AdminContext/AdminHandlers/Permissions/RemovePermission.cs
+++ b/Hotel.Domain/Handlers/AdminContext/AdminHandlers/Permissions/RemovePermission.cs
@@ -9,7 +9,7 @@ partial class AdminHandler
     //Buscar admin
     var admin = await _repository.GetAdminIncludePermissions(adminId);
     if (admin == null)
-      throw new ArgumentException("Admin não encontrado.");
+      throw new ArgumentException("Administrador não encontrado.");
 
     //Buscar permissão
     var permission = await _permissionRepository.GetEntityByIdAsync(permissionId);

--- a/Hotel.Domain/Handlers/AdminContext/AdminHandlers/Update.cs
+++ b/Hotel.Domain/Handlers/AdminContext/AdminHandlers/Update.cs
@@ -10,7 +10,7 @@ public partial class AdminHandler
   {
     var admin = await _repository.GetEntityByIdAsync(adminId);
     if (admin == null)
-      throw new ArgumentException("Não foi possível atualizar pois o Admin não existe.");
+      throw new ArgumentException("Não foi possível atualizar pois o Administrador não existe.");
     
     admin.ChangeName(new Name(model.FirstName,model.LastName));
     admin.ChangeEmail(new Email(model.Email));
@@ -22,6 +22,6 @@ public partial class AdminHandler
     _repository.Update(admin);
     await _repository.SaveChangesAsync();
 
-    return new Response<object>(200,"Admin atualizado com sucesso!",new { admin.Id });
+    return new Response<object>(200,"Administrador atualizado.");
   }
 }

--- a/Hotel.Domain/Middlewares/HandleExceptionsMiddleware.cs
+++ b/Hotel.Domain/Middlewares/HandleExceptionsMiddleware.cs
@@ -21,35 +21,35 @@ public class HandleExceptionMiddleware
     {
       context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
       await context.Response.WriteAsJsonAsync(
-        new Response<string>(400,e.Message)
+        new Response<string>(400,[e.Message])
       );
     }
     catch(ArgumentException e)
     {
       context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
       await context.Response.WriteAsJsonAsync(
-        new Response<string>(400,e.Message)
+        new Response<string>(400,[e.Message])
       );
     }
     catch (InvalidOperationException e)
     {
       context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
       await context.Response.WriteAsJsonAsync(
-        new Response<string>(400, e.Message)
+        new Response<string>(400,[e.Message])
       );
     }
     catch (DbUpdateException)
     {
       context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
       await context.Response.WriteAsJsonAsync(
-        new Response<string>(500,$"Não foi possível atualizar no banco de dados." )
+        new Response<string>(500,[$"Não foi possível atualizar no banco de dados."])
       );
     }
     catch(Exception e)
     {
       context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
       await context.Response.WriteAsJsonAsync(
-        new Response<string>(500,e.Message)
+        new Response<string>(500,[e.Message])
       );
     }
   }


### PR DESCRIPTION
-Criar a rota 'v1/admins/{id}/to-root-admin/{id}' para atender o serviço de mudar para administrador raiz; 
-Criar o handler ChangeToRootAdmin para lidar com a lógica; 
-Mudar o método ChangeToRootAdmin da entidade Admin(administrador) para verificar se já é ou não administrador raiz; 
-Adicionar construtor ao DTO 'Response' para aceitar os parâmetros de status e de mensagem